### PR TITLE
Removed TopP param from Execute chat for Bedrock REST client models

### DIFF
--- a/Apps.Anthropic/Api/AmazonBedrockRestClient.cs
+++ b/Apps.Anthropic/Api/AmazonBedrockRestClient.cs
@@ -116,7 +116,7 @@ public class AmazonBedrockRestClient : RestClient, IAnthropicClient
             {
                 maxTokens = message.MaxTokens,
                 temperature = message.Temperature ?? 0.5f,
-                topP = message.TopP ?? 1f
+              //  topP = message.TopP ?? 1f
             }
         };
         restRequest.AddJsonBody(payload);

--- a/Apps.Anthropic/Apps.Anthropic.csproj
+++ b/Apps.Anthropic/Apps.Anthropic.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Product>Anthropic</Product>
-    <Version>1.3.6</Version>
+    <Version>1.3.7</Version>
     <Description>A next-generation AI assistant for your tasks, no matter the scale</Description>
     <AssemblyName>Apps.Anthropic</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
Minor improvements